### PR TITLE
Fix typo

### DIFF
--- a/packages/local_modules/fm-loader/src/loader.js
+++ b/packages/local_modules/fm-loader/src/loader.js
@@ -5,7 +5,7 @@ const scriptsCache = {};
 export const loadScript = async (src) => {
 
   if (scriptsCache[src]) {
-    return scriptsCache;
+    return scriptsCache[src];
   }
 
   const dfd = deferred({ timeout: 30000 });


### PR DESCRIPTION
Found this repo and it's helpful examples from this thread https://github.com/webpack/webpack/issues/11033, but I noticed a possible typo that was causing things to break when I tried to load a component twice.